### PR TITLE
Pollen update

### DIFF
--- a/MMM-airquality.js
+++ b/MMM-airquality.js
@@ -90,11 +90,12 @@ Module.register("MMM-airquality", {
     pollenCountTitle.innerHTML = "Pollen count";
     mainWrapper.appendChild(pollenCountTitle);
 
-    // Row 4: Today's pollen counts
+    // Row 4: Today's pollen counts and species
     const pollenCounts = document.createElement("div");
     pollenCounts.className = "pollen-counts small bright";
     const counts = this.pollenData.Count;
     const risks = this.pollenData.Risk;
+    const species = this.pollenData.Species;
 
     let pollenAvailable = false;
 
@@ -103,6 +104,19 @@ Module.register("MMM-airquality", {
       grassDiv.innerHTML = `Grass Pollen: ${counts.grass_pollen} (${risks.grass_pollen})`;
       pollenCounts.appendChild(grassDiv);
       pollenAvailable = true;
+      
+      // Add Grass species
+      const grassSpecies = species.Grass;
+      const grassSpeciesDiv = document.createElement("div");
+      grassSpeciesDiv.className = "pollen-species xsmall dimmed";
+      let grassSpeciesHTML = '';
+      for (let sp in grassSpecies) {
+        if (grassSpecies[sp] > 0) {
+          grassSpeciesHTML += `${sp}: ${grassSpecies[sp]}<br>`;
+        }
+      }
+      grassSpeciesDiv.innerHTML = grassSpeciesHTML;
+      pollenCounts.appendChild(grassSpeciesDiv);
     }
 
     if (this.config.showTreePollen && counts.tree_pollen > 0) {
@@ -110,6 +124,19 @@ Module.register("MMM-airquality", {
       treeDiv.innerHTML = `Tree Pollen: ${counts.tree_pollen} (${risks.tree_pollen})`;
       pollenCounts.appendChild(treeDiv);
       pollenAvailable = true;
+      
+      // Add Tree species
+      const treeSpecies = species.Tree;
+      const treeSpeciesDiv = document.createElement("div");
+      treeSpeciesDiv.className = "pollen-species xsmall dimmed";
+      let treeSpeciesHTML = '';
+      for (let sp in treeSpecies) {
+        if (treeSpecies[sp] > 0) {
+          treeSpeciesHTML += `${sp}: ${treeSpecies[sp]}<br>`;
+        }
+      }
+      treeSpeciesDiv.innerHTML = treeSpeciesHTML;
+      pollenCounts.appendChild(treeSpeciesDiv);
     }
 
     if (this.config.showWeedPollen && counts.weed_pollen > 0) {
@@ -117,6 +144,19 @@ Module.register("MMM-airquality", {
       weedDiv.innerHTML = `Weed Pollen: ${counts.weed_pollen} (${risks.weed_pollen})`;
       pollenCounts.appendChild(weedDiv);
       pollenAvailable = true;
+      
+      // Add Weed species
+      const weedSpecies = species.Weed;
+      const weedSpeciesDiv = document.createElement("div");
+      weedSpeciesDiv.className = "pollen-species xsmall dimmed";
+      let weedSpeciesHTML = '';
+      for (let sp in weedSpecies) {
+        if (weedSpecies[sp] > 0) {
+          weedSpeciesHTML += `${sp}: ${weedSpecies[sp]}<br>`;
+        }
+      }
+      weedSpeciesDiv.innerHTML = weedSpeciesHTML;
+      pollenCounts.appendChild(weedSpeciesDiv);
     }
 
     if (!pollenAvailable) {

--- a/MMM-airquality.js
+++ b/MMM-airquality.js
@@ -96,83 +96,109 @@ Module.register("MMM-airquality", {
     const counts = this.pollenData.Count;
     const risks = this.pollenData.Risk;
 
+    let pollenAvailable = false;
+
     if (this.config.showGrassPollen && counts.grass_pollen > 0) {
       const grassDiv = document.createElement("div");
       grassDiv.innerHTML = `Grass Pollen: ${counts.grass_pollen} (${risks.grass_pollen})`;
       pollenCounts.appendChild(grassDiv);
+      pollenAvailable = true;
     }
 
     if (this.config.showTreePollen && counts.tree_pollen > 0) {
       const treeDiv = document.createElement("div");
       treeDiv.innerHTML = `Tree Pollen: ${counts.tree_pollen} (${risks.tree_pollen})`;
       pollenCounts.appendChild(treeDiv);
+      pollenAvailable = true;
     }
 
     if (this.config.showWeedPollen && counts.weed_pollen > 0) {
       const weedDiv = document.createElement("div");
       weedDiv.innerHTML = `Weed Pollen: ${counts.weed_pollen} (${risks.weed_pollen})`;
       pollenCounts.appendChild(weedDiv);
+      pollenAvailable = true;
+    }
+
+    if (!pollenAvailable) {
+      pollenCounts.innerHTML = "No Pollen";
     }
 
     mainWrapper.appendChild(pollenCounts);
 
-    // Conditionally show the pollen forecast
+    // Conditionally show the pollen forecast only if pollen is found in the selected types
     if (this.config.showPollenForecast) {
-      const separator = document.createElement("hr");
-      separator.className = "separator";
-      mainWrapper.appendChild(separator);
-
-      const forecastTitle = document.createElement("div");
-      forecastTitle.className = "forecast-title small bright";
-      forecastTitle.innerHTML = "Pollen Forecast";
-      mainWrapper.appendChild(forecastTitle);
-
-      const forecastTable = document.createElement("table");
-      forecastTable.className = "forecast-table small";
-
-      const headerRow = document.createElement("tr");
-      const dayHeader = document.createElement("th");
-      dayHeader.innerHTML = "Day";
-      const pollenTypeHeader = document.createElement("th");
-      pollenTypeHeader.innerHTML = "Pollen Type";
-      const riskHeader = document.createElement("th");
-      riskHeader.innerHTML = "Risk Level";
-      const countHeader = document.createElement("th");
-      countHeader.innerHTML = "Count";
-
-      headerRow.appendChild(dayHeader);
-      headerRow.appendChild(pollenTypeHeader);
-      headerRow.appendChild(riskHeader);
-      headerRow.appendChild(countHeader);
-      forecastTable.appendChild(headerRow);
-
       const forecastData = this.processForecastData(this.pollenForecastData);
 
-      forecastData.forEach(dayData => {
-        const row = document.createElement("tr");
-        row.className = "forecast-row";
+      const forecastHasSelectedPollen = forecastData.some(dayData =>
+        dayData.highestPollenTypes.some(pollenType => 
+          (pollenType.source === "Grass" && this.config.showGrassPollen) ||
+          (pollenType.source === "Tree" && this.config.showTreePollen) ||
+          (pollenType.source === "Weed" && this.config.showWeedPollen)
+        )
+      );
 
-        const dayCell = document.createElement("td");
-        dayCell.innerHTML = dayData.weekday;
-        row.appendChild(dayCell);
+      if (forecastHasSelectedPollen) {
+        const separator = document.createElement("hr");
+        separator.className = "separator";
+        mainWrapper.appendChild(separator);
 
-        const highestPollenType = dayData.highestPollenTypes[0];
-        const pollenTypeCell = document.createElement("td");
-        pollenTypeCell.innerHTML = highestPollenType.source;
-        row.appendChild(pollenTypeCell);
+        const forecastTitle = document.createElement("div");
+        forecastTitle.className = "forecast-title small bright";
+        forecastTitle.innerHTML = "Pollen Forecast";
+        mainWrapper.appendChild(forecastTitle);
 
-        const riskCell = document.createElement("td");
-        riskCell.innerHTML = highestPollenType.risk;
-        row.appendChild(riskCell);
+        const forecastTable = document.createElement("table");
+        forecastTable.className = "forecast-table small";
 
-        const countCell = document.createElement("td");
-        countCell.innerHTML = highestPollenType.count;
-        row.appendChild(countCell);
+        const headerRow = document.createElement("tr");
+        const dayHeader = document.createElement("th");
+        dayHeader.innerHTML = "Day";
+        const pollenTypeHeader = document.createElement("th");
+        pollenTypeHeader.innerHTML = "Pollen Type";
+        const riskHeader = document.createElement("th");
+        riskHeader.innerHTML = "Risk Level";
+        const countHeader = document.createElement("th");
+        countHeader.innerHTML = "Count";
 
-        forecastTable.appendChild(row);
-      });
+        headerRow.appendChild(dayHeader);
+        headerRow.appendChild(pollenTypeHeader);
+        headerRow.appendChild(riskHeader);
+        headerRow.appendChild(countHeader);
+        forecastTable.appendChild(headerRow);
 
-      mainWrapper.appendChild(forecastTable);
+        forecastData.forEach(dayData => {
+          dayData.highestPollenTypes.forEach(pollenType => {
+            if (
+              (pollenType.source === "Grass" && this.config.showGrassPollen) ||
+              (pollenType.source === "Tree" && this.config.showTreePollen) ||
+              (pollenType.source === "Weed" && this.config.showWeedPollen)
+            ) {
+              const row = document.createElement("tr");
+              row.className = "forecast-row";
+
+              const dayCell = document.createElement("td");
+              dayCell.innerHTML = dayData.weekday;
+              row.appendChild(dayCell);
+
+              const pollenTypeCell = document.createElement("td");
+              pollenTypeCell.innerHTML = pollenType.source;
+              row.appendChild(pollenTypeCell);
+
+              const riskCell = document.createElement("td");
+              riskCell.innerHTML = pollenType.risk;
+              row.appendChild(riskCell);
+
+              const countCell = document.createElement("td");
+              countCell.innerHTML = pollenType.count;
+              row.appendChild(countCell);
+
+              forecastTable.appendChild(row);
+            }
+          });
+        });
+
+        mainWrapper.appendChild(forecastTable);
+      }
     }
 
     wrapper.appendChild(mainWrapper);

--- a/README.md
+++ b/README.md
@@ -37,19 +37,23 @@ Here is an example of the configuration:
 ```bash
 {
   module: "MMM-airquality",
-  position: "bottom_right",            // Choose any position you´d like
+  position: "bottom_right",            // Choose any position you'd like
   config: {
     apiKey: "YOUR_AMBEE_API_KEY",      // Replace with your Ambee API Key
     latitude: "59.3293",               // Latitude of your location (Stockholm in this example)
     longitude: "18.0686",              // Longitude of your location
     showPM10: true,                    // Show PM10 data
     showPM25: true,                    // Show PM2.5 data
-    updateInterval: 3600000,           // Update every hour 100 calls a day limitation from api and we call several endpoints.
+    updateInterval: 3600000,           // Update every hour
     animationSpeed: 1000,              // 1 second for DOM animations
-    showPollenForecast: true,          // New option to control pollen forecast display
+    showPollenForecast: true,          // Control pollen forecast display
+    showGrassPollen: true,             // New option to show or hide Grass pollen
+    showTreePollen: true,              // New option to show or hide Tree pollen
+    showWeedPollen: true,              // New option to show or hide Weed pollen
     debug: false                       // Set to true to enable logging for debugging
   },
 },
+
 
 
 ```


### PR DESCRIPTION
New Configurable Pollen Type Display:

Added options to show or hide specific pollen types: showGrassPollen, showTreePollen, and showWeedPollen.
If no selected pollen type is present, a "No Pollen" message will be displayed.
Display Pollen Species Details:

For each pollen type (Grass, Tree, Weed) that is enabled and has available data, the species breakdown (e.g., Mugwort, Chenopod, Nettle) is now displayed beneath the pollen count.
This helps provide users with more granular information about specific pollens.
Conditional Pollen Forecast Display:

The forecast section is displayed only if there are relevant pollen types (based on the user's configuration) in the forecast data.
This ensures the forecast is only shown if it includes selected pollen types (Grass, Tree, or Weed).
Improved Data Loading Logic:

Enhanced loading checks to ensure that all required data (air quality, pollen, and forecast data) is fetched before updating the display.
Debug Logging:

Improved debug logging for better tracking of data fetching and processing.