### PR TITLE
Replace request by fetch

### DIFF
--- a/MMM-airquality.js
+++ b/MMM-airquality.js
@@ -311,7 +311,7 @@ Module.register("MMM-airquality", {
       });
 
       let weekday;
-      const today = new Date();
+      const today = new Date(Date.now());
       const tomorrow = new Date(today);
       tomorrow.setDate(today.getDate() + 1);
 

--- a/README.md
+++ b/README.md
@@ -13,33 +13,29 @@ A module for the [MagicMirror²](https://magicmirror.builders) to display air qu
 
 ## Installation
 
-1. Navigate to your MagicMirror `modules` folder:
+Just clone the module into your modules directory:
 
-    ```bash
-    cd ~/MagicMirror/modules
-    ```
+```bash
+cd ~/MagicMirror/modules
+git clone https://github.com/PierreGode/MMM-airquality
+```
 
-2. Clone the repository:
+## Update
 
-    ```bash
-    git clone https://github.com/PierreGode/MMM-airquality
-    ```
+Just enter the module's directory and pull the update:
 
-3. Navigate to the module folder:
-
-    ```bash
-    cd MMM-airquality
-    ```
-
-4. Install the dependencies:
-
-    ```bash
-    npm install
-    ```
+```bash
+cd ~/MagicMirror/modules/MMM-NHL
+git pull
+```
 
 ## Configuration
 
-To use this module, you will need to configure it in your config.js file of MagicMirror. You can obtain an API key from [ambee API](https://auth.ambeedata.com/users/register?redirectUrl=https://api-dashboard.getambee.com)
+To use this module, you need to configure it in your config.js file of MagicMirror.
+
+You can obtain an API key from [ambee API](https://auth.ambeedata.com/users/register?redirectUrl=https://api-dashboard.getambee.com)
+
+### Configuration Example
 
 Here is an example of the configuration:
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,20 +1,20 @@
+const Log = require("logger");
 const NodeHelper = require("node_helper");
-const request = require("request");
 
 module.exports = NodeHelper.create({
-  start: function () {
-    console.log("[MMM-airquality] Node Helper started");
+  start () {
+    Log.log("[MMM-airquality] Node Helper started");
   },
 
-  socketNotificationReceived: function (notification, payload) {
-    console.log(`[MMM-airquality] Received socket notification: ${notification}`);
+  socketNotificationReceived (notification, payload) {
+    Log.log(`[MMM-airquality] Received socket notification: ${notification}`);
     if (notification === "GET_DATA") {
-      console.log("[MMM-airquality] Fetching data for pollen, air quality, and pollen forecast...");
+      Log.log("[MMM-airquality] Fetching data for pollen, air quality, and pollen forecast...");
       this.getData(payload.apiKey, payload.latitude, payload.longitude);
     }
   },
 
-  getData: function (apiKey, latitude, longitude) {
+  async getData (apiKey, latitude, longitude) {
     const self = this;
 
     const pollenUrl = `https://api.ambeedata.com/latest/pollen/by-lat-lng?lat=${latitude}&lng=${longitude}`;
@@ -27,36 +27,44 @@ module.exports = NodeHelper.create({
     };
 
     // Fetch Pollen Data
-    request({ url: pollenUrl, headers: headers }, function (error, response, body) {
-      if (error || response.statusCode !== 200) {
-        console.error("[MMM-airquality] Error fetching pollen data:", error || response.statusCode);
-      } else {
-        const pollenResult = JSON.parse(body);
-        self.sendSocketNotification("POLLEN_RESULT", { data: pollenResult });
-        console.log("[MMM-airquality] Pollen data fetched");
+    try {
+      const response = await fetch(pollenUrl, {headers});
+      if (!response.ok) {
+        throw new Error(`[MMM-airquality] Error fetching pollen data: ${response.status}`);
       }
-    });
+      const data = await response.json();
+      self.sendSocketNotification("POLLEN_RESULT", {data});
+      Log.log("[MMM-airquality] Pollen data fetched");
+    } catch (error) {
+      Log.error("[MMM-airquality] Error fetching pollen data: " + error);
+    }
 
     // Fetch Air Quality Data
-    request({ url: airQualityUrl, headers: headers }, function (error, response, body) {
-      if (error || response.statusCode !== 200) {
-        console.error("[MMM-airquality] Error fetching air quality data:", error || response.statusCode);
-      } else {
-        const airQualityResult = JSON.parse(body).stations[0];
-        self.sendSocketNotification("AIR_QUALITY_RESULT", { data: airQualityResult });
-        console.log("[MMM-airquality] Air quality data fetched");
+    try {
+      const response = await fetch(airQualityUrl, {headers});
+      if (!response.ok) {
+        throw new Error(`[MMM-airquality] Error fetching air quality data: ${response.status}`);
       }
-    });
+      const data = await response.json();
+      const airQualityResult = data.stations[0];
+      self.sendSocketNotification("AIR_QUALITY_RESULT", {data: airQualityResult});
+      Log.log("[MMM-airquality] Air quality data fetched");
+    } catch (error) {
+      Log.error("[MMM-airquality] Error fetching air quality data: " + error);
+    }
 
     // Fetch Pollen Forecast Data
-    request({ url: pollenForecastUrl, headers: headers }, function (error, response, body) {
-      if (error || response.statusCode !== 200) {
-        console.error("[MMM-airquality] Error fetching pollen forecast data:", error || response.statusCode);
-      } else {
-        const pollenForecastResult = JSON.parse(body).data;
-        self.sendSocketNotification("POLLEN_FORECAST_RESULT", { data: pollenForecastResult });
-        console.log("[MMM-airquality] Pollen forecast data fetched");
+    try {
+      const response = await fetch(pollenForecastUrl, {headers});
+      if (!response.ok) {
+        throw new Error(`[MMM-airquality] Error fetching pollen forecast data: ${response.status}`);
       }
-    });
+      const data = await response.json();
+      const pollenForecastResult = data.data;
+      self.sendSocketNotification("POLLEN_FORECAST_RESULT", {data: pollenForecastResult});
+      Log.log("[MMM-airquality] Pollen forecast data fetched");
+    } catch (error) {
+      Log.error("[MMM-airquality] Error fetching pollen forecast data: " + error);
+    }
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mmm-airquality",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "A MagicMirror² module to display air quality information using data from the AirVisual API.",
     "repository": {
         "type": "git",
@@ -13,8 +13,5 @@
         "weather"
     ],
     "author": "PierreGode",
-    "license": "MIT",
-    "dependencies": {
-        "request": "^2.88.2"
-    }
+    "license": "MIT"
 }


### PR DESCRIPTION
I have removed the deprecated dependency `request`. This also has the advantage that the user no longer has to perform `npm install` after cloning.

Unfortunately I can't test it because I can't get an API key. I only get the following error message when I try to register: `Please enter your business email address.`