### PR TITLE
Replace node-fetch by internal fetch

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -1,6 +1,5 @@
 const Log = require("logger");
 const NodeHelper = require("node_helper");
-const fetch = require("node-fetch");
 
 module.exports = NodeHelper.create({
   start() {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,5 @@
     "weather"
   ],
   "author": "PierreGode",
-  "license": "MIT",
-  "dependencies": {
-    "node-fetch": "^2.6.7"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
node supports fetch since a while as a build-in function. So there is no need for node-fetch anymore. Otherwise the user would have to run `npm install`.